### PR TITLE
Update installation instructions...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ A Laravel / Filament starter kit for CMS functionality on websites.
 Install packages via composer
 
 ```bash
-composer require awcodes/trov awcodes/filament-addons awcodes/filament-curator awcodes/filament-tiptap-editor awcodes/filament-sentry
+composer require awcodes/trov awcodes/filament-addons awcodes/filament-curator awcodes/filament-tiptap-editor awcodes/filament-sentry awcodes/filament-versions
 ```
 
 Install optional packages
 
 ```bash
-composer require awcodes/filament-quick-create awcodes/filament-sticky-header awcodes/filament-versions
+composer require awcodes/filament-quick-create awcodes/filament-sticky-header
 ```
 
 ## Setup Filament Breezy


### PR DESCRIPTION
Following the current installation instructions results in this error:

```bash
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

   Error

  Class "FilamentVersions\FilamentVersionsWidget" not found

  at vendor/filament/filament/src/PluginServiceProvider.php:119
    115▕             }
    116▕         }
    117▕
    118▕         foreach ($this->getWidgets() as $widget) {
  ➜ 119▕             Livewire::component($widget::getName(), $widget);
    120▕         }
    121▕
    122▕         $this->registerMacros();
    123▕     }

      +9 vendor frames
  10  [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}(Object(Filament\FilamentServiceProvider))

      +5 vendor frames
  16  artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

It appears that the `awcodes/filament-versions` package is now required and not optional. I moved it to the base install snippet.